### PR TITLE
 Add Newsletter Subscription Functionality for Ultimate Member

### DIFF
--- a/um-to-newsletter.php
+++ b/um-to-newsletter.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Plugin Name: Newsletter Subscription for Ultimate Member
+ * Plugin URI: https://github.com/fahdi/um-to-newsletter/
+ * Description: This plugin extends the functionality of Ultimate Member by saving user registration details as a subscription in The Newsletter Plugin. It automatically subscribes users to your newsletter list during the registration process if they opt-in, ensuring seamless integration between user management and email marketing.
+ * Version: 1.0.0
+ * Author: Fahad Murtaza and Shahzad Raza
+ * Author URI: https://wpacademy.pk/
+ * License: GPL2
+ * Text Domain: /um-to-newsletter
+ */
+
+add_action( 'um_after_save_registration_details', 'um_after_save_registration_details', 10, 2 );
+
+function um_after_save_registration_details( $user_id, $submitted ) {
+
+	if ( isset( $submitted['newsletter_subscription'] ) && $submitted['newsletter_subscription'][0] === 'Yes' ) {
+
+		// Check if the user is not already subscribed
+		// Call the my_subscribe function to create a subscription
+		$subscription_result = um_my_subscribe( $submitted );
+
+		if ( is_wp_error( $subscription_result ) ) {
+			// Handle subscription error if needed
+			error_log( 'Error creating subscription for user with ID ' . $user_id );
+		} else {
+			error_log( 'User with ID ' . $user_id . ' subscribed successfully.' );
+		}
+	}
+}
+
+function um_my_subscribe( $submitted ) {
+
+	// Example: You can extract the email from the submitted data
+	$user_email = isset( $submitted['user_email'] ) ? $submitted['user_email'] : '';
+	$first_name = isset( $submitted['first_name'] ) ? $submitted['first_name'] : '';
+	$last_name  = isset( $submitted['last_name'] ) ? $submitted['last_name'] : '';
+
+	// You can also modify this function to set other subscription details
+	// based on the submitted data
+
+	// Create a subscription object and set its properties
+	$subscription                = NewsletterSubscription::instance()->get_default_subscription();
+	$subscription->data->email   = $user_email;
+	$subscription->data->name    = $first_name;
+	$subscription->data->surname = $last_name;
+
+	$subscription->optin = 'single'; // Or 'double' based on your requirements
+
+	// Call the subscribe2 method to create the subscription
+	$result = NewsletterSubscription::instance()->subscribe2( $subscription );
+
+	return $result;
+}


### PR DESCRIPTION
This PR introduces the `um-to-newsletter.php` file, a new plugin that seamlessly integrates Ultimate Member with The Newsletter Plugin. The primary goal of this plugin is to enhance user experience by automatically subscribing users to newsletters during the registration process, provided they opt-in for this service.

**Key Features:**
- **Automatic Newsletter Subscription:** Users who opt-in for newsletter subscription during their Ultimate Member registration will be automatically subscribed.
- **Seamless Integration:** The plugin works in the background, ensuring a smooth integration without disrupting the user's registration flow.
- **Error Logging:** Efficient error logging for subscription errors, aiding in troubleshooting and maintaining user experience.

**Technical Details:**
- The plugin hooks into the `um_after_save_registration_details` action.
- It checks if the user opted in for the newsletter subscription and subscribes them using `um_my_subscribe` function.
- It handles potential subscription errors and logs them for administrative review.

**Authors:** Fahad Murtaza and Shahzad Raza

**Version:** 1.0.0

**Future Scope:**
- Enhancements in subscription options.
- Additional customization for admin and user preferences.

This PR represents the initial version of the plugin, laying the groundwork for future features and improvements. Your feedback and contributions to this PR are highly appreciated to make this integration as robust and user-friendly as possible.
